### PR TITLE
fix(simplify): Simplify internal APIs

### DIFF
--- a/pkg/core/stream/stream_test.go
+++ b/pkg/core/stream/stream_test.go
@@ -44,18 +44,18 @@ func TestDecode(t *testing.T) {
 	testCases := []struct {
 		name string
 		data string
-		want []interface{}
+		want List
 		err  error
 	}{
-		{"Null", "A0", []interface{}{BytesData{[]byte{}}}, nil},
-		{"Call", "F8", []interface{}{TokenData{Call}}, nil},
-		{"Tiny byte", "A1 2F", []interface{}{BytesData{[]byte{0x2f}}}, nil},
-		{"Tiny uint", "2F", []interface{}{UIntData{0x2f}}, nil},
-		{"Short byte", "A1 8F", []interface{}{BytesData{[]byte{0x8f}}}, nil},
-		{"Short uint", "81 8F", []interface{}{UIntData{0x8f}}, nil},
-		{"8 bytes", "A8 01 02 03 04 05 06 07 08", []interface{}{BytesData{[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}}}, nil},
+		{"Null", "A0", List{[]byte{}}, nil},
+		{"Call", "F8", List{Call}, nil},
+		{"Tiny byte", "A1 2F", List{[]byte{0x2f}}, nil},
+		{"Tiny uint", "2F", List{uint(0x2f)}, nil},
+		{"Short byte", "A1 8F", List{[]byte{0x8f}}, nil},
+		{"Short uint", "81 8F", List{uint(0x8f)}, nil},
+		{"8 bytes", "A8 01 02 03 04 05 06 07 08", List{[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}}, nil},
 		{"16 bytes", "D0 10 01 02 03 04 05 06 07 08 01 02 03 04 05 06 07 08",
-			[]interface{}{BytesData{[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}}}, nil},
+			List{[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}}, nil},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -71,13 +71,13 @@ func TestDecodeLists(t *testing.T) {
 	testCases := []struct {
 		name string
 		data string
-		want []interface{}
+		want List
 		err  error
 	}{
 		{"Bad list", "F1", nil, ErrUnbalancedList},
-		{"Empty list", "F0 F1", []interface{}{[]interface{}{}}, nil},
-		{"One element", "F0 F8 F1", []interface{}{[]interface{}{TokenData{Call}}}, nil},
-		{"Two nested element", "F0 F0 F8 F8 F1 F1", []interface{}{[]interface{}{[]interface{}{TokenData{Call}, TokenData{Call}}}}, nil},
+		{"Empty list", "F0 F1", List{List{}}, nil},
+		{"One element", "F0 F8 F1", List{List{Call}}, nil},
+		{"Two nested element", "F0 F0 F8 F8 F1 F1", List{List{List{Call, Call}}}, nil},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This drops the custom datatypes from the core/stream API.
In the past I had some issues representing null bytes but I think
I have worked around that. This is a much much cleaner interface,
and using things like spew.Dump() is now perfectly readable!