### PR TITLE
feat(tcgdiskstat): Add stat utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 **/.*.sw?
-cmd/tcgstorage/tcgstorage
 target/

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -16,5 +16,7 @@ plugins:
           label: "tcgsdiag (Linux AMD64)"
         - path: "tcgsdiag.linux.arm64"
           label: "tcgsdiag (Linux ARM64)"
-
-
+        - path: "tcgdiskstat.linux.amd64"
+          label: "tcgdiskstat (Linux AMD64)"
+        - path: "tcgdiskstat.linux.arm64"
+          label: "tcgdiskstat (Linux ARM64)"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 .PHONY: build
 build:
 	go build ${LDFLAGS} -v -o target/tcgsdiag $(CURDIR)/cmd/tcgsdiag
+	go build ${LDFLAGS} -v -o target/tcgdiskstat $(CURDIR)/cmd/tcgdiskstat
 	go build ${LDFLAGS} -v -o target/sedlockctl $(CURDIR)/cmd/sedlockctl
 
 .PHONY: build-release
@@ -13,11 +14,13 @@ build-release: build-release-amd64 build-release-arm64
 .PHONY: build-release-amd64
 build-release-amd64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ${LDFLAGS} -o=tcgsdiag.linux.amd64 $(CURDIR)/cmd/tcgsdiag
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ${LDFLAGS} -o=tcgdiskstat.linux.amd64 $(CURDIR)/cmd/tcgdiskstat
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ${LDFLAGS} -o=sedlockctl.linux.amd64 $(CURDIR)/cmd/sedlockctl
 
 .PHONY: build-release-arm64
 build-release-arm64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ${LDFLAGS} -o=tcgsdiag.linux.arm64 $(CURDIR)/cmd/tcgsdiag
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ${LDFLAGS} -o=tcgdiskstat.linux.arm64 $(CURDIR)/cmd/tcgdiskstat
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ${LDFLAGS} -o=sedlockctl.linux.arm64 $(CURDIR)/cmd/sedlockctl
 
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Need support for another standard? Let us know by filing a feature request!
  * [tcgsdiag](cmd/tcgsdiag/README.md) lets you list a whole lot of diagnostic information about TCG drives.<br>
    Install it: `go install github.com/bluecmd/go-tcg-storage/cmd/tcgsdiag@main`
 
+ * [tcgdiskstat](cmd/tcgdiskstat/README.md) is like `blkid` or `lsscsi` but for TCG drives.<br>
+   Install it: `go install github.com/bluecmd/go-tcg-storage/cmd/tcgdiskstat@main`
+
+
 ## Supported Transports
 
 The following transports are supported by the library:

--- a/cmd/tcgdiskstat/README.md
+++ b/cmd/tcgdiskstat/README.md
@@ -1,0 +1,24 @@
+# tcgdiskstat
+
+Utility like `blkid` or `lsscsi` meant to be used to display state of
+disks supporting TCG Storage standards.
+
+It is read-only and does not authenticate or open sessions against the drive.
+
+Example usage:
+
+```
+$ tcgdisksstat
+DEVICE         MODEL                    SERIAL                 FIRMWARE   PROTOCOL   SSC        STATE
+/dev/nvme0n1   Sabrent Rocket 4.0 2TB   A0D6070C1EA788206263   RKT401.3   NVMe       Pyrite 1   lP
+```
+
+You can also use the JSON output together with example `jq`:
+
+```
+# Select a specific device
+$ tcgdiskstat --output json | jq '.[] | select(.Device == "/dev/nvme0n1")'
+
+# Grab specific properties for all devices
+$ tcgdiskstat --output json | jq -r '. | map(.Device, .Identity.Model, .Level0.Locking.LockingSupported)'
+```

--- a/cmd/tcgdiskstat/main.go
+++ b/cmd/tcgdiskstat/main.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	tcg "github.com/bluecmd/go-tcg-storage/pkg/core"
+	"github.com/bluecmd/go-tcg-storage/pkg/drive"
+)
+
+var (
+	outputFmt = flag.String("output", "table", "Output format; one of [table, json]")
+	noHeader  = flag.Bool("no-header", false, "Supress the header in table format output")
+)
+
+type DeviceState struct {
+	Device   string
+	Identity *drive.Identity
+	Level0   *tcg.Level0Discovery
+}
+
+type Devices []DeviceState
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+		fmt.Println()
+		flag.PrintDefaults()
+		fmt.Println()
+		fmt.Println("The following state flags might be shown:")
+		fmt.Println("  L/l - Locking is supported and is enabled (L) or disabled (l)")
+		fmt.Println("  M/m - MBR is enabled and is active (M) or hidden (m)")
+		fmt.Println("  E   - The device has media encryption")
+		fmt.Println("  P   - The Admin SP SID PIN is set to MSID [Block SID feature specific]")
+		fmt.Println("  !   - Authentication to Admin SP is blocked [Block SID feature specific]")
+		fmt.Println()
+	}
+	flag.Parse()
+
+	sysblk, err := ioutil.ReadDir("/sys/class/block/")
+	if err != nil {
+		log.Printf("Failed to enumerate block devices: %v", err)
+		return
+	}
+
+	var state Devices
+
+	for _, fi := range sysblk {
+		devname := fi.Name()
+		if _, err := os.Stat(filepath.Join("/sys/class/block", devname, "device")); os.IsNotExist(err) {
+			continue
+		}
+		devpath := filepath.Join("/dev", devname)
+		if _, err := os.Stat(devpath); os.IsNotExist(err) {
+			log.Printf("Failed to find device node %s", devpath)
+			continue
+		}
+
+		d, err := drive.Open(devpath)
+		if err != nil {
+			log.Printf("drive.Open(%s): %v", devpath, err)
+			continue
+		}
+		defer d.Close()
+		identity, err := d.Identify()
+		if err != nil {
+			log.Printf("drive.Identify(%s): %v", devpath, err)
+		}
+		d0, err := tcg.Discovery0(d)
+		if err != nil {
+			if err != tcg.ErrNotSupported {
+				log.Printf("tcg.Discovery0(%s): %v", devpath, err)
+			}
+			continue
+		}
+		state = append(state, DeviceState{
+			Device:   devpath,
+			Identity: identity,
+			Level0:   d0,
+		})
+	}
+
+	if *outputFmt == "json" {
+		outputJSON(state)
+	} else {
+		outputTable(state)
+	}
+}
+
+func outputJSON(state Devices) {
+	b, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		log.Fatalf("Failed to marshal JSON: %v", err)
+	}
+	os.Stdout.Write(b)
+}
+
+func outputTable(state Devices) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	if *noHeader == false {
+		fmt.Fprintf(w, "DEVICE\tMODEL\tSERIAL\tFIRMWARE\tPROTOCOL\tSSC\tSTATE\n")
+	}
+	for _, s := range state {
+		feat := []string{}
+		if s.Level0.Enterprise != nil {
+			feat = append(feat, "Enterprise")
+		}
+		if s.Level0.OpalV1 != nil {
+			feat = append(feat, "Opal 1")
+		}
+		if s.Level0.OpalV2 != nil {
+			feat = append(feat, "Opal 2")
+		}
+		if s.Level0.Opalite != nil {
+			feat = append(feat, "Opalite")
+		}
+		if s.Level0.PyriteV1 != nil {
+			feat = append(feat, "Pyrite 1")
+		}
+		if s.Level0.PyriteV2 != nil {
+			feat = append(feat, "Pyrite 2")
+		}
+		if s.Level0.RubyV1 != nil {
+			feat = append(feat, "Ruby 1")
+		}
+
+		state := ""
+		if l := s.Level0.Locking; l != nil {
+			if l.LockingEnabled {
+				state += "L"
+			} else if l.LockingSupported {
+				state += "l"
+			}
+
+			if l.MBREnabled {
+				if l.MBRDone {
+					state += "m"
+				} else {
+					state += "M"
+				}
+			}
+			if l.MediaEncryption {
+				state += "E"
+			}
+		}
+		if b := s.Level0.BlockSID; b != nil {
+			if !b.SIDValueState {
+				state += "P"
+			}
+			if b.SIDAuthenticationBlockedState {
+				state += "!"
+			}
+		}
+
+		fmt.Fprint(w,
+			s.Device, "\t",
+			s.Identity.Model, "\t",
+			s.Identity.SerialNumber, "\t",
+			s.Identity.Firmware, "\t",
+			s.Identity.Protocol, "\t",
+			strings.Join(feat, ","), "\t",
+			state, "\t",
+			"\n")
+	}
+	w.Flush()
+}

--- a/pkg/drive/drive.go
+++ b/pkg/drive/drive.go
@@ -23,11 +23,23 @@ const (
 	SecurityProtocolTCGTPer       SecurityProtocol = 2
 )
 
+type Identity struct {
+	Protocol     string
+	SerialNumber string
+	Model        string
+	Firmware     string
+}
+
+func (i *Identity) String() string {
+	return fmt.Sprintf("Protocol=%s, Model=%s, Serial=%s, Firmware=%s",
+		i.Protocol, i.Model, i.SerialNumber, i.Firmware)
+}
+
 type driveIntf interface {
 	IFRecv(proto SecurityProtocol, sps uint16, data *[]byte) error
 	IFSend(proto SecurityProtocol, sps uint16, data []byte) error
 
-	Identify() (string, error)
+	Identify() (*Identity, error)
 	SerialNumber() ([]byte, error)
 
 	Close() error


### PR DESCRIPTION
This tool is useful for enumerating disks and their TCG storage state.
This is similar to sedutil-cli --query and --scan.