### PR TITLE
minor(errors): Decode descriptor sense responses as well

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -130,6 +130,9 @@ func StackReset(d DriveIntf, comID ComID) error {
 func Discovery0(d DriveIntf) (*Level0Discovery, error) {
 	d0raw := make([]byte, 2048)
 	if err := d.IFRecv(drive.SecurityProtocolTCGManagement, uint16(ComIDDiscoveryL0), &d0raw); err != nil {
+		if err == drive.ErrNotSupported {
+			return nil, ErrNotSupported
+		}
 		return nil, err
 	}
 	d0 := &Level0Discovery{}


### PR DESCRIPTION
This fixes a whole class of responses that can tell us
that an attempted method is not supported by the drive.

Fixes #3 