### PR TITLE
fix: `LoadPBAImage()` uses MaxComPacketSize rather than MaxIndTokenSize

### DIFF
--- a/pkg/core/table/locking.go
+++ b/pkg/core/table/locking.go
@@ -587,9 +587,10 @@ func LoadPBAImage(s *core.Session, image []byte) error {
 
 	imgReader := bytes.NewReader(image)
 
-	// Calculate max chunk size
-	// Let's do it like sedutil-cli
-	maxSize := s.ControlSession.TPerProperties.MaxComPacketSize - 200 // 200 just picked a random huge number to count for ComPaket and packet headers
+	// Calculate max chunk size  - let's do it similar to sedutil-cli
+	// The chunk of data must fit in one token. Also keep a space for headers.
+	//     Note: 128B is more than sedutil-cli takes (56 + 50 + 4) and should be enough space
+	maxSize := s.ControlSession.TPerProperties.MaxIndTokenSize - 128
 	fpos := uint(0)
 	readChunk := make([]byte, maxSize)
 	for imgReader.Len() > 0 {


### PR DESCRIPTION
When communicating with the SED the maximum size of a package is limited by `MaxComPacketSize`. While the maximum size of an individual token is set by `MaxIndTokenSize`. When uploading chunks of the PBA the binary data is send - like other data - in  stream of tokens.

This means the chunk should not exceed the size of an individual token. The change also keeps some space in the chunk for the header. This number is taken from what `sedutil-cli` does with some margin for errors.

Assuming the original code worked on the drives under test before, it may mean that some drives firmware is more picky than others. The drives I checked (WD Black and Samsung Pro) worked with this change.